### PR TITLE
add uqhp eligible applicant for OEU notice preview

### DIFF
--- a/app/helpers/financial_application_helper.rb
+++ b/app/helpers/financial_application_helper.rb
@@ -267,7 +267,7 @@ module FinancialApplicationHelper
         :is_medicaid_chip_eligible => false,
         :is_totally_ineligible => true,
         :is_magi_medicaid => false,
-        :is_uqhp_eligible => nil,
+        :is_uqhp_eligible => true,
         :is_csr_eligible => false,
         :is_eligible_for_non_magi_reasons => false,
         :csr => "94",


### PR DESCRIPTION
[186076876](https://www.pivotaltracker.com/n/projects/2640057/stories/186076876)

Current FAA preview data does not include a uqhp_eligible applicant, so the OEA/OEU notice previews will not display certain tables. Setting an ineligible applicant to uqhp_eligible will allow these to display in preview for each notice.