### PR TITLE
map chip eligible notice to medicaid eligible notice

### DIFF
--- a/app/operations/magi_medicaid/generate_and_publish_eligibility_documents.rb
+++ b/app/operations/magi_medicaid/generate_and_publish_eligibility_documents.rb
@@ -43,6 +43,8 @@ module MagiMedicaid
 
     def determine_eligibilities(entity, event_key)
       unless event_key.to_s.include?('determined_mixed_determination') || event_key.to_s.include?('mixed_determination_on_reverification')
+        # The following ensures the event key is always determined_magi_medicaid_eligible to match the template model like below
+        event_key = event_key.gsub('determined_medicaid_chip_eligible', 'determined_magi_medicaid_eligible')
         return Success([event_key])
       end
 

--- a/spec/operations/magi_medicaid/generate_and_publish_eligibility_documents_spec.rb
+++ b/spec/operations/magi_medicaid/generate_and_publish_eligibility_documents_spec.rb
@@ -129,6 +129,32 @@ RSpec.describe MagiMedicaid::GenerateAndPublishEligibilityDocuments do
           expect(eligibilities.success).to eq []
         end
       end
+      
+      context 'when event key is medicaid_chip_eligible' do
+        event_keys = ['magi_medicaid.applications.aptc_csr_credits.renewals.determined_medicaid_chip_eligible', 'enroll.applications.aptc_csr_credits.renewals.notice.determined_medicaid_chip_eligible']
+        event_keys.each do |event_key|
+          let(:event_key) { event_key }
+          let(:eligibilities) do
+            MagiMedicaid::GenerateAndPublishEligibilityDocuments.new
+                                                                .determine_eligibilities(application_entity, event_key)
+          end
+          it 'should return magi_medicaid_eligible' do
+            prefix = event_key.split('.')[0..-2].join('.') # drop the last element
+            expect(eligibilities.success).to eq ["#{prefix}.determined_magi_medicaid_eligible"]
+          end
+        end
+      end
+      
+      context 'when event key is determined_aptc_eligible' do
+        let(:event_key) { 'magi_medicaid.applications.aptc_csr_credits.renewals.determined_aptc_eligible' }
+        let(:eligibilities) do
+          MagiMedicaid::GenerateAndPublishEligibilityDocuments.new
+                                                              .determine_eligibilities(application_entity, event_key)
+        end
+        it 'should return determined_aptc_eligible as is' do
+          expect(eligibilities.success).to eq [event_key]
+        end
+      end
     end
 
     context '#publish_documents' do


### PR DESCRIPTION
[TT6-186173087
](https://www.pivotaltracker.com/story/show/186173087)
`determined_medicaid_chip_eligible` notices should map to `determined_magi_medicaid_eligible` for consistency.

Included in this PR are specs for this mapping along with a general improvement for related specs.