### PR TITLE
pin rubygems version to 3.3.27

### DIFF
--- a/.docker/production/Dockerfile.gha
+++ b/.docker/production/Dockerfile.gha
@@ -63,7 +63,7 @@ ENV HOME=/polypress
 
 ENV PATH=$HOME/bin:$BUNDLE_BIN:$GEM_HOME/gems/bin:$PATH
 
-RUN gem update --system
+RUN gem update --system 3.3.27
 RUN rm -f /usr/local/bin/ruby/gems/*/specifications/default/bundler-*.gemspec
 RUN gem install bundler -v $BUNDLER_VERSION
 


### PR DESCRIPTION
[IVL Product Development - 186722046](https://www.pivotaltracker.com/story/show/186722046)

The latest version of the RubyGems dropped support of Ruby version 2.7. Refer to https://github.com/rubygems/rubygems/releases/