### PR TITLE
allow title tags to pass through scrubber

### DIFF
--- a/app/models/concerns/sanitize_concern.rb
+++ b/app/models/concerns/sanitize_concern.rb
@@ -17,7 +17,7 @@ module SanitizeConcern
 
       ActionController::Base.helpers.sanitize(
         pdf_string,
-        tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.dup.delete("select").add('style', 'title'),
+        tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.dup.delete("select").merge(['style', 'title']),
         attributes: Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES
       )
     end

--- a/app/models/concerns/sanitize_concern.rb
+++ b/app/models/concerns/sanitize_concern.rb
@@ -17,8 +17,8 @@ module SanitizeConcern
 
       ActionController::Base.helpers.sanitize(
         pdf_string,
-        tags: Loofah::HTML5::WhiteList::ACCEPTABLE_ELEMENTS.add('style'),
-        attributes: Loofah::HTML5::WhiteList::ACCEPTABLE_ATTRIBUTES
+        tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.dup.delete("select").add('style', 'title'),
+        attributes: Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES
       )
     end
   end

--- a/spec/models/concerns/sanitize_concern_spec.rb
+++ b/spec/models/concerns/sanitize_concern_spec.rb
@@ -11,7 +11,8 @@ describe FakeConcernTestClass, type: :model do
     context 'when the value is a string' do
       context 'when the value contains img tag' do
         let(:body) do
-          "<style>b {color: red}</style><script> x=new XMLHttpRequest;
+          "<title>Test</title>
+          <style>b {color: red}</style><script> x=new XMLHttpRequest;
           x.onload=function(){document.write(this.responseText)};
           x.open(\"GET\",\"file:////etc/passwd\");x.send() </script>
           <p class='red'>Uqhp Eligible Document for {{ family_reference.hbx_id }}
@@ -20,6 +21,7 @@ describe FakeConcernTestClass, type: :model do
 
         it 'should include whitelisted tags' do
           expect(subject.sanitize_pdf(body)).to include('<style>')
+          expect(subject.sanitize_pdf(body)).to include('<title>')
         end
 
         it 'should not include non-whitelisted tags' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187073164

# A brief description of the changes

Current behavior: Title tags are being removed via the HTML scrubber added, leading to whatever text that was wrapped in the tag to be printed on PDF reports.

New behavior: Title tags are allowed to pass through the scrubber, thus removing the text from PDF reports, specs added

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.