### PR TITLE
Bug fix on preview

### DIFF
--- a/app/helpers/family_helper.rb
+++ b/app/helpers/family_helper.rb
@@ -76,7 +76,7 @@ module FamilyHelper
   def insurance_agreements
     [
       {
-        plan_year: current_date.year,
+        plan_year: current_date.year - 1,
         start_on: current_date.beginning_of_year,
         contract_holder: contract_holder,
         insurance_provider: insurance_provider,


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2640060/stories/187248229 

(IVLVTA, IVLTAX, IVLTXC) throwing an error when I try to open from the eye/preview icon.
 
template is searching for 2024 template, we will generate it next year.

updating family helper to fetch previous year.