### PR TITLE
Bug fix on Sections Tab

### DIFF
--- a/app/operations/render_liquid.rb
+++ b/app/operations/render_liquid.rb
@@ -100,7 +100,7 @@ class RenderLiquid
   def fetch_entity_hash(params)
     return params[:entity].to_h unless params[:instant_preview] || params[:preview]
 
-    if params[:template].recipient.to_s == '::AcaEntities::Families::Family'
+    if !params[:template].is_a?(Hash) && params[:template]&.recipient&.to_s == '::AcaEntities::Families::Family'
       family_hash
     else
       application_hash


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187180506


this error is when we preview on sections tab


```
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] NoMethodError (undefined method `recipient' for #<Hash:0x000055cb3b58d6d8>):
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1]   
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] app/operations/render_liquid.rb:103:in `fetch_entity_hash'
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] app/operations/render_liquid.rb:150:in `construct_defaults'
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] app/operations/render_liquid.rb:61:in `render_body'
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] app/operations/render_liquid.rb:23:in `call'
[3407d6bc-76b1-46e1-a6d7-c7916f7b00c1] app/controllers/new/sections_controller.rb:73:in `instant_preview'
```

Reason for the issue, We are trying to fetch value on a hash as if it is an object. Either we need to build template object to able to do it, which is causing issues since we do not have some of the required values and failing model validations. Hence checking to see if its a not a hash then pick the application_hash since it is a built in helper.